### PR TITLE
Axis drawing: Ensure glVertex3fv call doesn't TypeError

### DIFF
--- a/pyparticles/ogl/axis_ogl.py
+++ b/pyparticles/ogl/axis_ogl.py
@@ -122,8 +122,8 @@ class AxisOgl(object):
         glBegin(GL_LINES)
         
         for pts in t :
-            glVertex3fv( pts[0] )
-            glVertex3fv( pts[1] )
+            glVertex3fv( pts[0].tolist() )
+            glVertex3fv( pts[1].tolist() )
             
         glEnd()
         
@@ -199,8 +199,8 @@ class AxisOgl(object):
         glBegin(GL_LINES)
         
         for pts in t :
-            glVertex3fv( pts[0] )
-            glVertex3fv( pts[1] )
+            glVertex3fv( pts[0].tolist() )
+            glVertex3fv( pts[1].tolist() )
         
             
         glEnd()

--- a/pyparticles/ogl/axis_ogl.py
+++ b/pyparticles/ogl/axis_ogl.py
@@ -122,8 +122,8 @@ class AxisOgl(object):
         glBegin(GL_LINES)
         
         for pts in t :
-            glVertex3fv( pts[0].tolist() )
-            glVertex3fv( pts[1].tolist() )
+            glVertex3fv( pts[0].view(type=np.ndarray) )
+            glVertex3fv( pts[1].view(type=np.ndarray) )
             
         glEnd()
         
@@ -199,8 +199,8 @@ class AxisOgl(object):
         glBegin(GL_LINES)
         
         for pts in t :
-            glVertex3fv( pts[0].tolist() )
-            glVertex3fv( pts[1].tolist() )
+            glVertex3fv( pts[0].view(type=np.ndarray) )
+            glVertex3fv( pts[1].view(type=np.ndarray) )
         
             
         glEnd()


### PR DESCRIPTION
PyOpenGL doesn't recognise numpy matrices as array-like. Closes #6